### PR TITLE
OPTEE AES128 Decryption support added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,18 @@ set(DRM_PLUGIN_NAME "ClearKey")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+option(OPTEE_AES_DECRYPTOR "Enable AES Decryption on OP-TEE environment" OFF)
+
 if(NOT NAMESPACE)
    set(NAMESPACE "WPEFramework")
 endif()
 
+if(OPTEE_AES_DECRYPTOR)
+find_package(OPTEEClearKey REQUIRED)
+add_compile_definitions(OPTEE_AES128)
+else()
 find_package(ClearKey REQUIRED)
+endif()
 
 file(GLOB DRM_PLUGIN_INCLUDES *.h)
 

--- a/cmake/FindOPTEEClearKey.cmake
+++ b/cmake/FindOPTEEClearKey.cmake
@@ -1,0 +1,36 @@
+# Once done this will define
+#  CLEARKEY_INCLUDE_DIRS - The directories where OPTEE Clearkey TA headers available
+#  CLEARKEY_LIBRARIES - has the OPTEE Clearkey static library
+#
+# Copyright (C) 2019 Linaro Limited.
+# Copyright (C) 2019 Metrological.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+#
+
+find_path (CLEARKEY_INCLUDE_DIRS NAME "aes_crypto.h" PATHS "usr/include/")
+find_library(CLEARKEY_LIBRARIES NAME aes_crypto PATH_SUFFIXES lib)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(CLEARKEY DEFAULT_MSG CLEARKEY_INCLUDE_DIRS CLEARKEY_LIBRARIES)
+
+mark_as_advanced(CLEARKEY_INCLUDE_DIRS CLEARKEY_LIBRARIES)


### PR DESCRIPTION
Decryption will be held on Trusted Environment.
https://github.com/linaro-mmwg/optee-clearkey-cdmi

Once this feature enabled, wpeframework-ocdm-clearkey has to add
this Trusted App dependency which is available as a yocto recipe in
https://github.com/linaro-mmwg/meta-lhg/blob/master/meta-lhg/recipes-security/optee/optee-aes-decryptor.bb

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>