### PR TITLE
runtime fix: f_cbIV size should also matches with AES block size

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -170,7 +170,7 @@ CDMi_RESULT MediaKeySession::Decrypt(
     unsigned int block_offset = 0;
 
 
-    assert(f_cbIV <  AES_BLOCK_SIZE);
+    assert(f_cbIV <= AES_BLOCK_SIZE);
 
     if (!f_pcbOpaqueClearContent) {
         cout << "ERROR: f_pcbOpaqueClearContent is NULL" << endl;


### PR DESCRIPTION
Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>